### PR TITLE
Fix packages when building.

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1255,6 +1255,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
     },
+    "node_modules/@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==",
+      "license": "MIT"
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -4476,6 +4482,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@types/jest": "^29.5.3",
         "@types/node": "^18.11.9",
+        "@types/object-inspect": "^1.13.0",
         "codemirror": "^6.0.1",
         "gdparse": "^1.0.2",
         "immutable": "^4.1.0",
         "node-fetch": "^3.3.2",
-        "type-fest": "^3.12.0"
+        "type-fest": "^3.12.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "chokidar": "^3.5.3",
@@ -1274,6 +1276,12 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "node_modules/@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w==",
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -4511,6 +4519,15 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -5514,6 +5531,11 @@
       "version": "18.11.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+    },
+    "@types/object-inspect": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@types/object-inspect/-/object-inspect-1.13.0.tgz",
+      "integrity": "sha512-lwGTVESDDV+XsQ1pH4UifpJ1f7OtXzQ6QBOX2Afq2bM/T3oOt8hF6exJMjjIjtEWeAN2YAo25J7HxWh97CCz9w=="
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -7864,6 +7886,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@types/jest": "^29.5.3",
     "@types/node": "^18.11.9",
+    "@types/object-inspect": "^1.13.0",
     "codemirror": "^6.0.1",
     "gdparse": "^1.0.2",
     "immutable": "^4.1.0",
     "node-fetch": "^3.3.2",
-    "type-fest": "^3.12.0"
+    "type-fest": "^3.12.0",
+    "zod": "^3.23.8"
   },
   "scripts": {
     "watch-all": "npm run dev --prefix desmoscript",


### PR DESCRIPTION
When attempting to run `npm install` and `npm run dev --prefix desmoscript`, an error is presented since the packages "zod" and "object-inspect" are not present in the "package.json" and "package-lock.json" files.